### PR TITLE
[refactor] Implicitly enable Jira integration via API key

### DIFF
--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -66,7 +66,6 @@ jobs:
             --env-var JIRA_API_KEY=${{ secrets.JIRA_API_KEY }} \
             --env-var JIRA_BASE_URL=https://thesolesupplier.atlassian.net \
             --env-var JIRA_BOT_USER_ID=5e5ab50ba17f930c9b964563 \
-            --env-var JIRA_INTEGRATION_ENABLED=true \
             --env-var JIRA_PROJECT_KEY=TFW \
             --env-var JIRA_WEBHOOK_SECRET=${{ secrets.JIRA_WEBHOOK_SECRET }} \
             --env-var LOG_LEVEL=INFO \

--- a/README.md
+++ b/README.md
@@ -33,20 +33,16 @@ with:
   # Required.
   github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # Enable Jira integration.
-  # Default: `false`.
-  jira_integration_enabled: "false"
-
   # Jira username and API key (base64 encoded `<username>:<api_token>`).
-  # Required if Jira is enabled.
+  # Required for Jira integration.
   jira_api_key: ""
 
   # Jira instance base URL (e.g., https://my-company.atlassian.net).
-  # Required if Jira is enabled.
+  # Required if `jira_api_key` is provided.
   jira_base_url: ""
 
   # Jira project key.
-  # Required if Jira is enabled.
+  # Required if `jira_api_key` is provided.
   jira_project_key:
 
   # Slack webhook URL for the release summary.

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,6 @@ inputs:
   github_token:
     description: GitHub token to access the repository. This should automatically be available as a secret.
     required: true
-  jira_integration_enabled:
-    description: Enable Jira integration. Defaults to `false`.
-    required: false
   jira_api_key:
     description: Base64-encoded `<username>:<api_token>` for Jira with read permissions. Required if Jira is enabled.
     required: false
@@ -78,7 +75,6 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         JIRA_API_KEY: ${{ inputs.jira_api_key }}
         JIRA_BASE_URL: ${{ inputs.jira_base_url }}
-        JIRA_INTEGRATION_ENABLED: ${{ inputs.jira_integration_enabled }}
         JIRA_PROJECT_KEY: ${{ inputs.jira_project_key }}
         REPOS_DIR: ./repos
         SLACK_MESSAGE_ENABLED: true

--- a/action/src/main.rs
+++ b/action/src/main.rs
@@ -95,10 +95,9 @@ pub async fn get_jira_issues(
     pull_requests: &[PullRequest],
     commit_messages: &[String],
 ) -> Result<Option<Vec<Issue>>> {
-    let jira_integration =
-        config::get_optional("JIRA_INTEGRATION_ENABLED").is_some_and(|v| v == "true");
+    let jira_enabled = config::get_optional("JIRA_API_KEY").is_some();
 
-    if !jira_integration {
+    if !jira_enabled {
         return Ok(None);
     }
 

--- a/api/README.md
+++ b/api/README.md
@@ -32,7 +32,6 @@ Expects an [issue_updated](https://developer.atlassian.com/cloud/jira/platform/w
 
 The following environment variables are **required**:
 
-- `JIRA_INTEGRATION_ENABLED` - _(set to `true`)_
 - `JIRA_API_KEY` - _(base64 encoded `<username>:<api_token>`)_
 - `JIRA_BASE_URL`
 - `JIRA_BOT_USER_ID`

--- a/shared/src/services/jira.rs
+++ b/shared/src/services/jira.rs
@@ -108,9 +108,9 @@ impl Issue {
     }
 
     async fn add_comment<T: Serialize + Debug>(&self, comment: T) -> Result<()> {
-        let jira_integration_enabled = config::get("JIRA_INTEGRATION_ENABLED") == "true";
+        let jira_enabled = config::get_optional("JIRA_API_KEY").is_some();
 
-        if !jira_integration_enabled {
+        if !jira_enabled {
             println!("------ JIRA COMMENT ------");
             println!("{comment:#?}");
             println!("--------------------------");
@@ -149,9 +149,9 @@ impl Issue {
     }
 
     pub async fn delete_outdated_comments(&self) -> Result<()> {
-        let jira_integration_enabled = config::get("JIRA_INTEGRATION_ENABLED") == "true";
+        let jira_enabled = config::get_optional("JIRA_API_KEY").is_some();
 
-        if !jira_integration_enabled {
+        if !jira_enabled {
             return Ok(());
         }
 


### PR DESCRIPTION
Removes the need to explicitly enable Jira integration via the `JIRA_INTEGRATION_ENABLED` env variable by implicitly enabling it if the `JIRA_API_KEY` env variable is provided.