### PR TITLE
[feat] Improve handling of non-master branch workflow runs for release summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
     # ...deployment steps
 
   anno:
-    uses: thesolesupplier/anno@v2
+    uses: thesolesupplier/anno@v3
     needs:
       - prod-deploy
 ```

--- a/shared/src/services/github/repository.rs
+++ b/shared/src/services/github/repository.rs
@@ -7,6 +7,7 @@ pub struct Repository {
     pub full_name: String,
     pub name: String,
     pulls_url: String,
+    html_url: String,
     compare_url: String,
     contents_url: String,
     commits_url: String,
@@ -18,6 +19,10 @@ impl Repository {
             "https://github.com/{}/compare/{}...{}",
             self.full_name, old_sha, new_sha
         )
+    }
+
+    pub fn get_commit_url(&self, sha: &str) -> String {
+        format!("{}/commit/{sha}", self.html_url)
     }
 
     pub async fn get_pull_requests_for_commit(&self, sha: &str) -> Result<Vec<PullRequest>> {
@@ -94,7 +99,51 @@ impl Repository {
         Ok(response)
     }
 
-    pub async fn fetch_diff(&self, old_sha: &str, new_sha: &str) -> Result<String> {
+    pub async fn get_diff_for_commit(&self, sha: &str) -> Result<String> {
+        tracing::info!("Fetching diff for commit {sha}");
+
+        let gh_token = AccessToken::get().await?;
+        let url = self.commits_url.replace("{/sha}", &format!("/{sha}"));
+
+        let diff = reqwest::Client::new()
+            .get(url)
+            .bearer_auth(gh_token)
+            .header("Accept", "application/vnd.github.diff")
+            .header("User-Agent", "Anno")
+            .send()
+            .await?
+            .error_for_status()
+            .inspect_err(|e| tracing::error!("Error getting commit diff: {e}"))?
+            .text()
+            .await?;
+
+        Ok(diff)
+    }
+
+    pub async fn get_commit_message(&self, sha: &str) -> Result<String> {
+        tracing::info!("Fetching commit message for commit {sha}");
+
+        let gh_token = AccessToken::get().await?;
+        let url = self.commits_url.replace("{/sha}", &format!("/{sha}"));
+
+        let message = reqwest::Client::new()
+            .get(url)
+            .bearer_auth(gh_token)
+            .header("Accept", "application/json")
+            .header("User-Agent", "Anno")
+            .send()
+            .await?
+            .error_for_status()
+            .inspect_err(|e| tracing::error!("Error getting commit message: {e}"))?
+            .json::<Commit>()
+            .await?
+            .commit
+            .message;
+
+        Ok(message)
+    }
+
+    pub async fn get_diff_between_commits(&self, old_sha: &str, new_sha: &str) -> Result<String> {
         tracing::info!("Fetching diff between commits {old_sha} and {new_sha}");
 
         let gh_token = AccessToken::get().await?;


### PR DESCRIPTION
#### Summary

Enhances the release summary functionality to better handle non-master branch workflow runs. The update adds dedicated handling for branch-specific releases, improves diff generation, and restructures the workflow run fetching process to support both branch-specific and general workflow histories.
<details><summary>Details</summary><br>

- Added `handle_branch_release` function to process releases for non-master branches
- Added `handle_master_release` function to handle master branch releases with previous run comparisons
- Updated `WorkflowRuns` to support both branch-specific and general workflow history fetching
- Added new Repository methods: `get_diff_for_commit`, `get_commit_message`, and `get_commit_url`
- Modified `slack::ReleaseSummary` to handle optional previous run URLs and different diff URL types
- Updated action version from `v2` to `v3` in README.md
- Improved error messages and logging for better debugging
</details>