### PR TITLE
[feat] Add "compare to master" button to workflow summaries

### DIFF
--- a/action/src/slack.rs
+++ b/action/src/slack.rs
@@ -7,9 +7,10 @@ use shared::{
 };
 
 pub struct ReleaseSummary<'a> {
-    pub app_name: Option<&'a str>,
+    pub app_name: String,
     pub jira_issues: Vec<Issue>,
     pub diff_url: String,
+    pub compare_to_master_url: String,
     pub prev_run_url: Option<&'a String>,
     pub pull_requests: Vec<PullRequest>,
     pub run: &'a WorkflowRun,
@@ -59,13 +60,11 @@ impl ReleaseSummary<'_> {
     }
 
     fn get_header_block(&self) -> Value {
-        let app_name = self.app_name.unwrap_or(&self.run.repository.name);
-
         json!({
             "type": "header",
             "text": {
                 "type": "plain_text",
-                "text": format!("{app_name} release :rocket:"),
+                "text": format!("{} release :rocket:", self.app_name),
                 "emoji": true
             }
         })
@@ -189,6 +188,14 @@ impl ReleaseSummary<'_> {
                     "text": "Diff",
                 },
                 "url": self.diff_url
+            }),
+            json!({
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Compare to master",
+                },
+                "url": self.compare_to_master_url
             }),
         ]);
 

--- a/shared/src/services/github/repository.rs
+++ b/shared/src/services/github/repository.rs
@@ -6,11 +6,12 @@ use serde::Deserialize;
 pub struct Repository {
     pub full_name: String,
     pub name: String,
+    pub html_url: String,
     pulls_url: String,
-    html_url: String,
     compare_url: String,
     contents_url: String,
     commits_url: String,
+    default_branch: String,
 }
 
 impl Repository {
@@ -164,6 +165,13 @@ impl Repository {
             .await?;
 
         Ok(diff)
+    }
+
+    pub fn get_compare_to_master_url(&self, commit: &str) -> String {
+        format!(
+            "{}/compare/{}...{}",
+            self.html_url, commit, self.default_branch
+        )
     }
 }
 


### PR DESCRIPTION
#### Summary

Adds a new "Compare to master" button to workflow summaries in Slack notifications, allowing users to quickly view the comparison between the current branch and master branch on GitHub.
<details><summary>Details</summary><br>

- Added new button in `ReleaseSummary` struct that links to GitHub comparison view
- Implemented `get_compare_to_master_url()` method in `WorkflowRun` to generate comparison URL
- Made `html_url` field public in `Repository` struct to support URL generation
- Button appears alongside existing workflow summary buttons in Slack messages
</details>