### PR TITLE
[feat] Add paths argument to action inputs for file filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ with:
   # Slack webhook URL for the release summary.
   # Required.
   slack_webhook_url: ""
+
+  # Newline-separated list of glob patterns for file paths to include or exclude in analysis.
+  # Default: All paths.
+  paths: ""
 ```
 
 **Note:** Ensure Anno requires the previous job(s) to complete first so that it runs only after your deployment is successful:
@@ -59,10 +63,25 @@ jobs:
       - prod-deploy
 ```
 
+### File Filtering with paths
 
-## Monorepo Usage
+You can control which files Anno analyses using the paths input. This is useful for any repository but especially helpful in monorepos:
 
-There shouldn't be any special setup required for monorepos. Anno will download the workflow file and use the [`on.push.paths`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths) and [`on.push.paths-ignore`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-paths) properties to determine which files and commits to include in its analysis:
+```yaml
+uses: thesolesupplier/anno@v3
+with:
+  paths: |-
+    sub-project/**
+    !sub-project/docs/**
+```
+
+This accepts newline or comma-separated glob patterns and takes precedence over any [`on.push.paths`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths) and [`on.push.paths-ignore`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-paths)  settings in your workflow file.
+
+If no paths are provided, Anno will fall back to using the workflow file's `on.push` settings. If neither are present, Anno will default to the entire repository.
+
+### Monorepo Usage
+
+There’s no special setup required for monorepos. Anno automatically reads your workflow file and uses the [`on.push.paths`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths) and [`on.push.paths-ignore`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-paths) properties to determine which files and commits to include in its analysis:
 
 ```yaml
 on:
@@ -72,7 +91,7 @@ on:
       - '!sub-project/docs/**'
 ```
 
-If neither are specified, Anno will default to the entire repository.
+However, for more precise control (or to override the workflow config), use the paths input as shown above.
 
 ## API Features
 

--- a/action.yml
+++ b/action.yml
@@ -26,9 +26,12 @@ inputs:
   slack_webhook_url:
     description: Slack webhook URL for the release summary.
     required: true
+  paths:
+    description: Newline or comma-separated list of glob patterns to filter files used in analysis.
+    required: false
 
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Set reusable variables
       shell: bash
@@ -75,6 +78,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         JIRA_API_KEY: ${{ inputs.jira_api_key }}
         JIRA_BASE_URL: ${{ inputs.jira_base_url }}
+        PATHS: ${{ inputs.paths }}
         REPOS_DIR: ./repos
         SLACK_MESSAGE_ENABLED: true
         SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}

--- a/action/src/git.rs
+++ b/action/src/git.rs
@@ -1,4 +1,4 @@
-use super::workflows::WorkflowTargetPaths;
+use super::target_paths::TargetPaths;
 use anyhow::Result;
 use git2::{Commit, Oid};
 use shared::{services::github::AccessToken, utils::config};
@@ -51,7 +51,7 @@ impl Git {
         &self,
         start_commit: &str,
         end_commit: &str,
-        target_paths: &WorkflowTargetPaths,
+        target_paths: &TargetPaths,
     ) -> Result<Vec<String>> {
         tracing::info!("Getting commit messages between commits {start_commit} and {end_commit}");
 
@@ -84,13 +84,16 @@ impl Git {
     fn get_commit_message(
         &self,
         commit: Oid,
-        target_paths: &WorkflowTargetPaths,
+        target_paths: &TargetPaths,
     ) -> Result<Option<String>> {
         let commit = self.repo.find_commit(commit)?;
 
         let affected_files = self.get_affected_files(&commit)?;
 
-        if !affected_files.iter().any(|p| target_paths.is_included(p)) {
+        if !affected_files
+            .iter()
+            .any(|p| target_paths.is_path_included(p))
+        {
             return Ok(None);
         }
 

--- a/action/src/target_paths.rs
+++ b/action/src/target_paths.rs
@@ -1,0 +1,102 @@
+use super::workflows::WorkflowConfig;
+use glob::Pattern;
+use regex_lite::Regex;
+use shared::{services::github::IGNORED_REPO_PATHS, utils::config};
+
+#[derive(Debug, Default)]
+pub struct TargetPaths {
+    included: Vec<Pattern>,
+    excluded: Vec<Pattern>,
+}
+
+impl TargetPaths {
+    pub fn new(workflow_config: WorkflowConfig) -> Self {
+        if let Some(target_paths) = Self::get_paths_from_action_input() {
+            let (included, excluded) = Self::split_paths(&target_paths);
+
+            return Self {
+                included: Self::create_patterns(included),
+                excluded: Self::create_patterns(excluded),
+            };
+        }
+
+        let Some(push_config) = workflow_config.push_config() else {
+            return Self::default();
+        };
+
+        let paths = push_config.paths.as_deref().unwrap_or_default();
+        let ignored_paths = push_config.paths_ignore.as_deref().unwrap_or_default();
+
+        if paths.is_empty() && ignored_paths.is_empty() {
+            return Self::default();
+        }
+
+        let (included, mut excluded) = Self::split_paths(paths);
+
+        for path in ignored_paths {
+            excluded.push(path);
+        }
+
+        Self {
+            included: Self::create_patterns(included),
+            excluded: Self::create_patterns(excluded),
+        }
+    }
+
+    pub fn filter_diff(&self, diff: &str) -> String {
+        let re = Regex::new(r"b/([^ ]+)").unwrap();
+
+        let mut is_inside_ignored_file = false;
+        diff.lines()
+            .filter(|line| {
+                if line.starts_with("diff --git") {
+                    if let Some(caps) = re.captures(line) {
+                        let path = caps[1].to_string();
+
+                        let is_ignored_file = IGNORED_REPO_PATHS.iter().any(|p| path.contains(p));
+                        let is_non_target_file = !self.is_path_included(&path);
+
+                        is_inside_ignored_file = is_ignored_file || is_non_target_file;
+                    }
+                }
+
+                !is_inside_ignored_file
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    pub fn is_path_included(&self, path: &str) -> bool {
+        let is_included = self.included.is_empty() || self.included.iter().any(|p| p.matches(path));
+        let is_excluded = self.excluded.iter().any(|p| p.matches(path));
+
+        is_included && !is_excluded
+    }
+
+    fn get_paths_from_action_input() -> Option<Vec<String>> {
+        let target_paths = config::get_optional("PATHS");
+
+        let target_paths = target_paths?
+            .split([',', '\n'])
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        Some(target_paths)
+    }
+
+    fn split_paths(paths: &[String]) -> (Vec<&String>, Vec<&String>) {
+        paths
+            .iter()
+            .filter(|p| IGNORED_REPO_PATHS.iter().all(|i| !p.contains(i)))
+            .partition::<Vec<_>, _>(|p| !p.starts_with('!'))
+    }
+
+    fn create_patterns(paths: Vec<&String>) -> Vec<Pattern> {
+        paths
+            .iter()
+            .map(|p| Pattern::new(p.strip_prefix('!').unwrap_or(p)))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap_or_default()
+    }
+}


### PR DESCRIPTION
#### Summary

Adds a new `paths` input parameter to the Anno action that allows users to specify which files to include or exclude in the analysis using glob patterns. This feature provides more precise control over file filtering, especially useful in monorepo setups, and takes precedence over workflow-level path configurations.
<details><summary>Details</summary><br>

- Added new `paths` input parameter to `action.yml` that accepts newline or comma-separated glob patterns
- Updated README with documentation and examples for the new `paths` input
- Refactored path filtering logic into a new `target_paths` module
- Added `TargetPaths::get_paths_from_action_input()` to parse paths from environment variable
- Modified file filtering to prioritize action-level paths over workflow `on.push.paths` settings
- Updated error messaging to be more generic when no files match the configured paths
</details>