### PR TITLE
[refactor] Simplify PR summaries by removing details section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 /repos
 .env.prod
+*/target

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If no paths are provided, Anno will fall back to using the workflow file's `on.p
 
 ### Monorepo Usage
 
-There’s no special setup required for monorepos. Anno automatically reads your workflow file and uses the [`on.push.paths`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths) and [`on.push.paths-ignore`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-paths) properties to determine which files and commits to include in its analysis:
+There should be no special setup required for monorepos. Anno uses your workflow's [`on.push.paths`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths) and [`on.push.paths-ignore`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-paths) properties to determine which files and commits to include in its analysis:
 
 ```yaml
 on:

--- a/action/src/git.rs
+++ b/action/src/git.rs
@@ -12,7 +12,7 @@ impl Git {
         let repos_dir = config::get("REPOS_DIR");
         let gh_token = AccessToken::get().await?;
 
-        let repo_name = full_name.split('/').last().unwrap_or(full_name);
+        let repo_name = full_name.split('/').next_back().unwrap_or(full_name);
         let repo_url = format!("https://x-access-token:{gh_token}@github.com/{full_name}");
         let repo_disk_path = format!("{repos_dir}/{}", repo_name.replace('-', "_"));
 

--- a/api/src/ai/pr_summary.rs
+++ b/api/src/ai/pr_summary.rs
@@ -1,12 +1,11 @@
 use anyhow::Result;
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use shared::services::{claude, jira::Issue};
 
 #[derive(Deserialize)]
 pub struct PrSummary {
     pub summary: String,
-    pub details: Vec<String>,
 }
 
 impl PrSummary {
@@ -47,32 +46,9 @@ impl PrSummary {
         .send()
         .await
     }
-
-    pub fn into_markdown_body(self) -> String {
-        let mut body = format!(
-            "#### Summary\n\n{}\n<details><summary>Details</summary><br>\n\n",
-            self.summary
-        );
-
-        for detail in self.details {
-            body.push_str(&format!("- {detail}\n"));
-        }
-
-        body.push_str("</details>");
-
-        body
-    }
 }
 
 fn response_schema() -> Value {
-    let details = json!({
-        "type": "array",
-        "description": "An array of strings representing the technical details of the pull request. Use single backticks to format single line references to code if needed.",
-        "items": {
-            "type": "string"
-        }
-    });
-
     let summary = json!({
       "type": "string",
       "description": "A block of text summarising the pull request."
@@ -84,11 +60,9 @@ fn response_schema() -> Value {
         "type": "object",
         "properties": {
           "summary": summary,
-          "details": details,
         },
         "required": [
           "summary",
-          "details"
         ],
         "additionalProperties": false
       },
@@ -98,9 +72,8 @@ fn response_schema() -> Value {
 const SYSTEM_PROMPT: &str = "
     <Instructions>
         Your task is to summarise a pull request to make it easier for other team members to understand the changes before reviewing.
-        You should provide a high-level summary of the changes as well as a separate, detailed list breaking down the most important changes.
         Use the diff, commit messages, and Jira issues (if provided) to summarise the code changes and how they relate to the feature or bug described in the issues.
-        Keep your summary short, clear and concise so that it provides a high-level overview of the changes and their impact.
+        Keep your summary very short, clear and concise so that it provides a high-level overview of the changes and their impact.
         Use direct language and avoid redundant phrases; the fewer words you use, the clearer your summary will be.
         Avoid including any personal opinions or feedback in your summary, as this is a factual summary of the changes.
         Provide the summary without any introductory or concluding statements.
@@ -109,7 +82,6 @@ const SYSTEM_PROMPT: &str = "
         - Review the diff to understand the changes made in the pull request.
         - Review the commit messages to understand the context of the changes.
         - Review the Jira issues to understand the feature or bug being addressed.
-        - Write a detailed, technical description of the changes made in the pull request.
         - Write a summary that explains the changes made in the pull request and how they relate to the feature or bug.
         - Keep your summary clear and concise, focusing on the high-level changes made in the pull request.
         - Provide the summary without any personal opinions or feedback, as this is a factual summary of the changes.

--- a/api/src/routes/github/pull_request.rs
+++ b/api/src/routes/github/pull_request.rs
@@ -94,7 +94,7 @@ pub async fn get_jira_issues(pr: &PullRequest) -> Result<Vec<Issue>> {
         for key in key_regex.find_iter(body) {
             keys.insert(key.as_str());
         }
-    };
+    }
 
     let requests = keys.into_iter().map(Issue::get_by_key).collect::<Vec<_>>();
 
@@ -117,19 +117,14 @@ pub fn get_pr_body(summary: ai::PrSummary, pr: &PullRequest, issues: &[Issue]) -
     }
 
     if !issues.is_empty() {
-        body.push_str("#### Tickets\n");
+        body.push_str("**Tickets**\n");
 
         for issue in issues {
-            body.push_str(&format!(
-                "- [{} - {}]({})\n",
-                issue.key,
-                issue.fields.summary.trim(),
-                issue.get_browse_url()
-            ));
+            body.push_str(&format!("- {}\n", issue.get_github_hyperlink()));
         }
     }
 
-    body.push_str(&summary.into_markdown_body());
+    body.push_str(&format!("**Summary**\n\n{}", summary.summary));
 
     body
 }

--- a/shared/src/services/jira.rs
+++ b/shared/src/services/jira.rs
@@ -44,6 +44,15 @@ impl Issue {
         let jira_base_url = config::get("JIRA_BASE_URL");
         format!("{jira_base_url}/browse/{}", self.key)
     }
+
+    pub fn get_github_hyperlink(&self) -> String {
+        format!(
+            "[{} - {}]({})\n",
+            self.key,
+            self.fields.summary.trim(),
+            self.get_browse_url()
+        )
+    }
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
#### Summary

Simplifies PR summary generation by removing the detailed breakdown section. Updates the PR body formatting to be more concise, changes heading styles from `####` to `**`, and improves Jira ticket link formatting. Also includes minor improvements to repository path handling and .gitignore patterns.
<details><summary>Details</summary><br>

- Removes `details` field from `PrSummary` struct and related functionality
- Updates PR body formatting to use bold text (`**`) instead of heading markers (`####`)
- Improves Jira ticket link formatting with new `get_github_hyperlink()` method
- Changes repository name extraction in `Git` struct to use `next_back()` instead of `last()`
- Updates monorepo documentation wording in README.md
- Adds `*/target` to .gitignore for better handling of workspace builds
</details>